### PR TITLE
Apply feedrate limit and jerk to all axes

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2585,7 +2585,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
     uint8_t limited = 0;
     #if BOTH(JUNCTION_DEVIATION, LIN_ADVANCE)
-      LOOP_XYZ(i)
+      LOOP_NON_E(i)
     #else
       LOOP_NUM_AXIS(i)
     #endif
@@ -2622,7 +2622,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
       // Now limit the jerk in all axes.
       const float smaller_speed_factor = vmax_junction / previous_nominal_speed;
       #if BOTH(JUNCTION_DEVIATION, LIN_ADVANCE)
-        LOOP_XYZ(axis)
+        LOOP_NON_E(axis)
       #else
         LOOP_NUM_AXIS(axis)
       #endif


### PR DESCRIPTION
### Description

Untested change in planner. It looks as if these changes were missed in the initial 6 axis code. Maybe on purpose? Should be tried out. Ultimately, jerk/junktion deviation should be dependent on the kinematics. Not sure if this change goes into the correct direction. 

### Benefits

Apply feedrate limits and jerk similarly to all axes. 

### Related Issues

None